### PR TITLE
fix V2 docs link

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 #### V 1.1.X  
-For [V2 docs click here](https://github.com/wix/react-native-navigation/tree/v2)
+For [V2 docs click here](https://wix.github.io/react-native-navigation/v2/#/)
 
 - Getting started
  - [Installation - iOS](/installation-ios)


### PR DESCRIPTION
v2 docs link liked to GitHub and not to the official wix docs (which is where people are likely wanting to go)

Thx